### PR TITLE
ci: disable L2 E2E tests (no test:e2e:api script)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,4 @@ jobs:
         pre-command: "bun run build"
         test-command: "bun run test"
         typecheck-command: "true"
+        enable-l2: "false"


### PR DESCRIPTION
## Problem
pew-game CI fails at L2 API E2E step because `test:e2e:api` script doesn't exist in package.json.

The CI workflow uses base-ci which defaults `enable-l2: "true"`, but this repo has no E2E API tests.

## Fix
Add `enable-l2: "false"` to the CI workflow `with:` block.

---
*Dispatched via Multica (MUL-428)* 🍊