### PR TITLE
fix: regenerate bun.lock after 6DQ hooks update

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@types/react-dom": "^19.1.0",
         "eslint": "^9.25.0",
         "eslint-config-next": "^16.1.6",
+        "husky": "^9.1.7",
         "tailwindcss": "^4.2.0",
         "typescript": "^5.9.3",
       },
@@ -542,6 +543,8 @@
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 


### PR DESCRIPTION
## Summary
Regenerate `bun.lock` after the 6DQ hooks update commit (`ceefd94`) modified `package.json` but didn't update the lockfile.

**CI Error**: `error: lockfile had changes, but lockfile is frozen`

## Changes
- Regenerated `bun.lock` via `bun install`
