### PR TITLE
ci(6dq): add G2 security scanning

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "gitleaks config"
+
+[allowlist]
+  paths = [
+    '.*\.test\.ts',
+    '.*\.spec\.ts',
+    '.*__tests__.*',
+  ]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,6 @@
-bun run test && bun run lint
+# === Quality Gate: pre-commit ===
+# L1 + G1 + G2a (6DQ standard)
+bun run typecheck
+bun run lint
+bun run test
+gitleaks protect --staged --no-banner

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,4 @@
 bun run build && bun run test && bun run lint && bun run test:e2e
+
+# G2b: dependency vulnerability scan
+osv-scanner scan --lockfile=bun.lock --config=osv-scanner.toml


### PR DESCRIPTION
## 6DQ G2 Security Scanning Compliance

Adds G2 (security scanning) to meet 6DQ quality standard:

### Changes
- **`.gitleaks.toml`** — Secret detection configuration with test file allowlist
- **`osv-scanner.toml`** — Dependency vulnerability scanner configuration
- **Pre-commit hook** — Added `gitleaks protect --staged` (G2a) + `typecheck` if missing
- **Pre-push hook** — Added `osv-scanner scan` (G2b)

### 6DQ Standard Reference
- **G2a (Secrets)**: gitleaks in pre-commit — zero tolerance for leaked secrets
- **G2b (Dependencies)**: osv-scanner in pre-push — scan lockfile for known CVEs
- **Benchmark**: Zhe project (Tier S standard)
