### PR TITLE
chore(security): adopt base-ci v2026.2 ignore-scripts (Shai-Hulud defense)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ on:
 
 jobs:
   ci:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.1
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.2
     with:
+        ignore-scripts: true
         pre-command: "bun run build"
         test-command: "bun run test:coverage"
         typecheck-command: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
     uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.2
     with:
         ignore-scripts: true
-        pre-command: "bun run build"
+        # better-sqlite3 ships native bindings via prebuild-install. Under
+        # ignore-scripts the package's install script is skipped, so we
+        # invoke it explicitly here before the Next.js build runs.
+        pre-command: "(cd node_modules/better-sqlite3 && bun run install) && bun run build"
         test-command: "bun run test:coverage"
         typecheck-command: "true"
         enable-security: "true"

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,13 @@
       },
     },
   },
+  "trustedDependencies": [
+    "husky",
+    "better-sqlite3",
+    "@tailwindcss/oxide",
+    "sharp",
+    "unrs-resolver",
+  ],
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/package.json
+++ b/package.json
@@ -38,5 +38,13 @@
     "*.{ts,tsx}": [
       "eslint --max-warnings=0"
     ]
-  }
+  },
+  "trustedDependencies": [
+    "@tailwindcss/oxide",
+    "better-sqlite3",
+    "esbuild",
+    "husky",
+    "sharp",
+    "unrs-resolver"
+  ]
 }


### PR DESCRIPTION
## Summary

- Bumps the `nocoo/base-ci/.github/workflows/bun-quality.yml` reusable workflow from `@v2026.1` to `@v2026.2`.
- Enables `ignore-scripts: true` on the workflow call, so all `bun install` steps in CI run with `--ignore-scripts` (Shai-Hulud / npm supply-chain worm defense).
- Adds `trustedDependencies` to `package.json` for native-binary packages (`@tailwindcss/oxide`, `better-sqlite3`, `esbuild`, `husky`, `sharp`, `unrs-resolver`).

## Notes for reviewer

Local-only verification used `bun install` (no `--ignore-scripts`):

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run build` ✅
- `bun run test` ✅ (100 passed)

⚠️ Behavior caveat observed under bun 1.3.13: `bun install --ignore-scripts` skips lifecycle scripts even for packages listed in `trustedDependencies`. Reproduced in an isolated test project — with `trustedDependencies: ["better-sqlite3"]`, running `bun install --ignore-scripts` does **not** produce `better_sqlite3.node`. This may break L1 unit tests in CI (which import `better-sqlite3`). Letting this PR's CI run definitively confirm; if it fails, the reusable workflow likely needs to invoke `bun pm trust --all` (or `bun install` without the flag for the trusted set) after the `--ignore-scripts` install pass.

## Test plan

- [ ] base-ci CI run is green on this PR (typecheck, lint, L1 unit tests, build, gitleaks, osv-scanner)
- [ ] If L1 unit tests fail with `Could not locate the bindings file` for `better-sqlite3`, raise base-ci-side fix (post-install `bun pm trust --all` step or equivalent)