### PR TITLE
chore(security): adopt base-ci v2026.4 trustedDependencies whitelist (Shai-Hulud defense)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
   ci:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.2
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
     with:
         ignore-scripts: true
+        trusted-native-deps: "better-sqlite3"
         pre-command: "bun run build"
         test-command: "bun run test:coverage"
         typecheck-command: "true"


### PR DESCRIPTION
Bumps base-ci to v2026.4 (trustedDependencies model, replaces broken v2026.3 `bun pm trust` approach). Declares trustedDependencies in package.json so bun runs postinstall only for listed native deps (better-sqlite3).