### PR TITLE
chore(ci): pin base-ci reusable workflow to v2026.5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ci:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
         ignore-scripts: true
         trusted-native-deps: "better-sqlite3"


### PR DESCRIPTION
## Summary

Pin the `nocoo/base-ci` reusable workflow reference from the floating tag `@v2026.4` to the immutable commit SHA `aec4adc1a817c56790d1698329ef9398a15a754a` (v2026.5).

```diff
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
```

## Why

Floating `@v2026.x` tags can be silently retargeted by a tag rewrite or force-push in the upstream `nocoo/base-ci` repository, breaking the supply-chain guarantee of third-party action references. Pinning to the peeled commit SHA makes the reference byte-immutable: even if `base-ci` itself is compromised, no new code is pulled into this repository's CI without an explicit SHA bump here. The trailing comment ` # v2026.5` preserves human-readable version context.

## Scope

- Only `.github/workflows/ci.yml` references `nocoo/base-ci`; that single `uses:` line is the only change.
- No application code, dependencies, or other CI inputs touched.

## Verification

- `rg '@v2026' .github/workflows/` — no matches; no floating refs remain.
- `actionlint .github/workflows/*.yml` — clean.
- `git ls-remote https://github.com/nocoo/base-ci refs/tags/v2026.5^{}` confirms peeled commit `aec4adc1a817c56790d1698329ef9398a15a754a`.

## Test plan

- [ ] CI green on this PR (`bun-quality.yml` reusable workflow runs at the new SHA)
